### PR TITLE
Make locales module optional

### DIFF
--- a/lib/jst.js
+++ b/lib/jst.js
@@ -5,9 +5,19 @@
  */
 
 var fs = require('fs'),
-    locales = require('locales'),
     filters = require('./filters'),
-    hash = require('./hash');
+    hash = require('./hash'),
+    locales;
+
+try {
+  locales = requires('locales');
+} catch(e) {
+  locales = {
+    configure: function(){},
+    gettext : function(s) { return s },
+    ngettext : function(s) { return s}
+  }
+}
 
 exports.version = '0.0.10';
 


### PR DESCRIPTION
If we do not include `locales` module, jst can simply return string itself.
