### PR TITLE
The call of callback function was issued out of try-catch.

### DIFF
--- a/lib/jst.js
+++ b/lib/jst.js
@@ -109,7 +109,8 @@ var renderFile = exports.renderFile = function(filename, args, fn) {
     args = {};
   }
 
-  var fk = hash.md5sum(filename);
+  var fk = hash.md5sum(filename),
+      res;
 
   fs.stat(filename, function(err, stats) {
     if (err)
@@ -126,13 +127,15 @@ var renderFile = exports.renderFile = function(filename, args, fn) {
         _files[fk].ctx = ctx;
 
         try {
-          fn(null, render(ctx, args));
+          res = render(ctx, args);
         } catch(e) { fn(e); }
+        fn(null, res);
       });
     } else {
       try {
-        fn(null, render(_files[fk].ctx, args));
+        res = render(_files[fk].ctx, args);
       } catch(e) { fn(e); }
+      fn(null, res);
     }
   });
 }


### PR DESCRIPTION
Since callback function is called in try-catch, when callback function has a bug, but looked like error in jst.renderFile.

``` js
var jst = require('./node-jst/lib/jst.js');
jst.renderFile('test.jst', {}, function(err, res) {
  if (err) {
    console.log('error in jst.renderFile: ' + err);
    return;
  }
  var a = null;
  a.b;   // bug's code
});
```

```
error in jst.renderFile: TypeError: Cannot read property 'b' of null
```

I consider that it is better to call a callback function outside try-catch. 
