### PR TITLE
This a fix for template using multiline {% %} statements

### DIFF
--- a/jst.js
+++ b/jst.js
@@ -71,7 +71,7 @@ var jst = {};
 
     _options.useIt = /{{ (e\()?it\./.test(ctx);
 
-    ctx = ctx.replace(/[\t\r\n]/g, '').replace(/\{#.+?#\}/g, '')
+    ctx = ctx.replace(/[\t\r\n]/g, ' ').replace(/\{#.+?#\}/g, ' ')
 
     if (!_options.useIt) {
       code += '""; with(it) {';

--- a/jst.js
+++ b/jst.js
@@ -71,7 +71,7 @@ var jst = {};
 
     _options.useIt = /{{ (e\()?it\./.test(ctx);
 
-    ctx = ctx.replace(/[\t\r\n]/g, ' ').replace(/\{#.+?#\}/g, ' ')
+    ctx = ctx.replace(/[\t\r\n]/g, '').replace(/\{#.+?#\}/g, '')
 
     if (!_options.useIt) {
       code += '""; with(it) {';

--- a/jst.js
+++ b/jst.js
@@ -58,7 +58,7 @@ var jst = {};
   }
 
   var prefixes = {
-        n: {s: '"', c: '', v: ''},
+        n: {s: '"', c: '""; ', v: ''},
         s: {s: '', c: '"; ', v: '" + '},
         c: {s: ' out += "', c: ' ', v: ' out += '},
         v: {s: ' + "', c: '; ', v: ' + '},
@@ -71,7 +71,7 @@ var jst = {};
 
     _options.useIt = /{{ (e\()?it\./.test(ctx);
 
-    ctx = ctx.replace(/[\t\r\n]/g, '').replace(/\{#.+?#\}/g, '')
+    ctx = ctx.replace(/[\t\r\n]/g, ' ').replace(/\{#.+?#\}/g, ' ')
 
     if (!_options.useIt) {
       code += '""; with(it) {';

--- a/lib/jst.js
+++ b/lib/jst.js
@@ -34,7 +34,7 @@ exports.addFilters = function(newFilters) {
 // compiler
 
 const prefixes = {
-        n: {s: '"', c: '', v: ''},
+        n: {s: '"', c: '""; ', v: ''},
         s: {s: '', c: '"; ', v: '" + '},
         c: {s: ' out += "', c: ' ', v: ' out += '},
         v: {s: ' + "', c: '; ', v: ' + '},
@@ -47,7 +47,7 @@ var compile = exports.compile = function(ctx) {
 
   _options.useIt = /{{ (e\()?it\./.test(ctx);
 
-  ctx = ctx.replace(/[\t\r\n]/g, '').replace(/\{#.+?#\}/g, '')
+  ctx = ctx.replace(/[\t\r\n]/g, ' ').replace(/\{#.+?#\}/g, ' ')
 
   if (!_options.useIt) {
     code += '""; with(it) {';


### PR DESCRIPTION
When using {% (js code) \n%}, the \n is removed and the %} tag is next
to a javascript statement causing a parsing error.
Eg:
{%
myArray = [];
%}
=> {%myArray=[];%} instead of {% myArray=[]; %}
